### PR TITLE
Update status.lua

### DIFF
--- a/wx_rpchat/server/status.lua
+++ b/wx_rpchat/server/status.lua
@@ -63,7 +63,7 @@ RegisterCommand(wx.Commands['Status'], function(source, args, rawCommand)
             TriggerClientEvent('wx_rpchat:RemovePlayerStatus', -1, _source)
             Notify('Success',"You have removed your status")
         else
-            local message = args[1]
+            local message = table.concat(args, ' ', 1)
             playerStatus[_source] = message
             TriggerClientEvent('wx_rpchat:SetPlayerStatus', -1, _source, message)
             log("**/status**", source,GetPlayerName(source), message,steam,discord,ip,stavwebhook)


### PR DESCRIPTION
Now the user can type anything he wants, before was something like: /status knee hurts, the code used to return just "knee" an workaround was to type /status *knee hurts* 
with this quick fix the user doesn't need to worry about this anymore!